### PR TITLE
Feature clang support

### DIFF
--- a/src/flash/nor/stm32f1x.c
+++ b/src/flash/nor/stm32f1x.c
@@ -1374,9 +1374,9 @@ COMMAND_HANDLER(stm32x_handle_options_read_command)
 	}
 
 	command_print(CMD_CTX, "User Option0: 0x%02" PRIx8,
-			(user_data >> stm32x_info->user_data_offset) & 0xff);
+			(uint8_t) ((user_data >> stm32x_info->user_data_offset) & 0xff));
 	command_print(CMD_CTX, "User Option1: 0x%02" PRIx8,
-			(user_data >> (stm32x_info->user_data_offset + 8)) & 0xff);
+			(uint8_t) ((user_data >> (stm32x_info->user_data_offset + 8)) & 0xff));
 
 	return ERROR_OK;
 }

--- a/src/jtag/drivers/ft2232.c
+++ b/src/jtag/drivers/ft2232.c
@@ -1511,7 +1511,7 @@ static void minimodule_reset(int trst, int srst)
 
 static void turtle_reset(int trst, int srst)
 {
-	trst = trst;
+	trst = (int) trst;
 
 	if (srst == 1)
 		low_output |= nSRST;

--- a/src/rtos/rtos.c
+++ b/src/rtos/rtos.c
@@ -191,7 +191,7 @@ static char *next_symbol(struct rtos *os, char *cur_symbol, uint64_t cur_addr)
 int rtos_qsymbol(struct connection *connection, char *packet, int packet_size)
 {
 	int rtos_detected = 0;
-	uint64_t addr;
+	uint64_t addr = 0;
 	size_t reply_len;
 	char reply[GDB_BUFFER_SIZE], cur_sym[GDB_BUFFER_SIZE / 2] = "", *next_sym;
 	struct target *target = get_target_from_connection(connection);

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -5022,7 +5022,7 @@ static int target_create(Jim_GetOptInfo *goi)
 	}
 
 	/* now - create the new target name command */
-	const const struct command_registration target_subcommands[] = {
+	const struct command_registration target_subcommands[] = {
 		{
 			.chain = target_instance_command_handlers,
 		},
@@ -5031,7 +5031,7 @@ static int target_create(Jim_GetOptInfo *goi)
 		},
 		COMMAND_REGISTRATION_DONE
 	};
-	const const struct command_registration target_commands[] = {
+	const struct command_registration target_commands[] = {
 		{
 			.name = cp,
 			.mode = COMMAND_ANY,


### PR DESCRIPTION
This makes it possible to build openocd with clang with at least --enable-ft2232_libftdi configured.
