### PR TITLE
Add support for floating point in register stacking

### DIFF
--- a/src/rtos/rtos_standard_stackings.c
+++ b/src/rtos/rtos_standard_stackings.c
@@ -67,6 +67,26 @@ static const struct stack_register_offset rtos_standard_Cortex_M4_Pebble_stack_o
 	{ 0x44, 32 }, /* xPSR */
 };
 
+static const struct stack_register_offset rtos_standard_Cortex_M4_Pebble_stack_offsets_with_fp[ARMV7M_NUM_CORE_REGS] = {
+	{ 0x68, 32 }, /* r0 */
+	{ 0x6c, 32 }, /* r1 */
+	{ 0x70, 32 }, /* r2 */
+	{ 0x74, 32 }, /* r3 */
+	{ 0x04, 32 }, /* r4 */
+	{ 0x08, 32 }, /* r5 */
+	{ 0x0c, 32 }, /* r6 */
+	{ 0x10, 32 }, /* r7 */
+	{ 0x14, 32 }, /* r8 */
+	{ 0x18, 32 }, /* r9 */
+	{ 0x1c, 32 }, /* r10 */
+	{ 0x20, 32 }, /* r11 */
+	{ 0x78, 32 }, /* r12 */
+	{ -2,   32 }, /* sp */
+	{ 0x7c, 32 }, /* lr */
+	{ 0x80, 32 }, /* pc */
+	{ 0x84, 32 }, /* xPSR */
+};
+
 static const struct stack_register_offset rtos_standard_Cortex_M3_stack_offsets[ARMV7M_NUM_CORE_REGS] = {
 	{ 0x20, 32 },		/* r0   */
 	{ 0x24, 32 },		/* r1   */
@@ -169,6 +189,14 @@ const struct rtos_register_stacking rtos_standard_Cortex_M4_Pebble_stacking = {
 	ARMV7M_NUM_CORE_REGS,					/* num_output_registers */
 	8,					/* stack_alignment */
 	rtos_standard_Cortex_M4_Pebble_stack_offsets	/* register_offsets */
+};
+
+const struct rtos_register_stacking rtos_standard_Cortex_M4_Pebble_stacking_with_fp = {
+	0xD0,				/* stack_registers_size (FP adds 34 words: s0-s31, FPSCR, and Reserved */
+	-1,					/* stack_growth_direction */
+	ARMV7M_NUM_CORE_REGS,					/* num_output_registers */
+	8,					/* stack_alignment */
+	rtos_standard_Cortex_M4_Pebble_stack_offsets_with_fp	/* register_offsets */
 };
 
 const struct rtos_register_stacking rtos_standard_Cortex_M3_stacking = {

--- a/src/rtos/rtos_standard_stackings.h
+++ b/src/rtos/rtos_standard_stackings.h
@@ -32,5 +32,6 @@ extern const struct rtos_register_stacking rtos_standard_Cortex_R4_stacking;
 extern const struct rtos_register_stacking rtos_standard_NDS32_N1068_stacking;
 extern const struct rtos_register_stacking rtos_standard_Cortex_M3_Pebble_stacking;
 extern const struct rtos_register_stacking rtos_standard_Cortex_M4_Pebble_stacking;
+extern const struct rtos_register_stacking rtos_standard_Cortex_M4_Pebble_stacking_with_fp;
 
 #endif	/* ifndef INCLUDED_RTOS_STANDARD_STACKINGS_H_ */


### PR DESCRIPTION
@chrisc11 Can you review? This fixes openocd so that it can get the right registers and backtrace when the task is using floating point. 
