### PR TITLE
🍒 sim3x: fix build failure with clang 3.6

### DIFF
--- a/src/flash/nor/sim3x.c
+++ b/src/flash/nor/sim3x.c
@@ -864,14 +864,12 @@ static int sim3x_flash_info(struct flash_bank *bank, char *buf, int buf_size)
 				return ERROR_BUF_TOO_SMALL;
 
 			/* Package */
-			if (sim3x_info->device_package) {
-				printed = snprintf(buf, buf_size, "-G%s", sim3x_info->device_package);
-				buf += printed;
-				buf_size -= printed;
+			printed = snprintf(buf, buf_size, "-G%s", sim3x_info->device_package);
+			buf += printed;
+			buf_size -= printed;
 
-				if (buf_size <= 0)
-					return ERROR_BUF_TOO_SMALL;
-			}
+			if (buf_size <= 0)
+				return ERROR_BUF_TOO_SMALL;
 		}
 	}
 


### PR DESCRIPTION
This fixes a warning as reported by the current clang version:
../../../../src/flash/nor/sim3x.c:867:20: error: address of array
'sim3x_info->device_package' will always evaluate to 'true' .

Change-Id: Ie160cbe6df8f491e9beff38d47e2f13575529bf9
Signed-off-by: Paul Fertser fercerpav@gmail.com
Reviewed-on: http://openocd.zylin.com/2838
Tested-by: jenkins
Reviewed-by: Oleksij Rempel
Reviewed-by: Andreas Färber afaerber@suse.de
Reviewed-by: Spencer Oliver spen@spen-soft.co.uk
